### PR TITLE
Add header directives to helmet

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -59,7 +59,7 @@ app.use(
   helmet.contentSecurityPolicy({
     // override default script-src directive to include cloudflare cdn, and github static content
     // should consider overriding this to allow individual front-ends set Content-Security-Policy on meta tags themselves if list of exceptions grow
-    // like so: <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com;" >
+    // like so: <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'  https://cdnjs.cloudflare.com; 'img-src' 'self' https://github.com https://raw.githubusercontent.com;" >
     directives: {
       'script-src': ["'self'", 'https://cdnjs.cloudflare.com', "'unsafe-inline'"],
       'img-src': ["'self'", 'https://github.com', 'https://raw.githubusercontent.com'],

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -64,7 +64,7 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         'script-src': ["'self'", 'https://cdnjs.cloudflare.com', "'unsafe-inline'"],
-        'img-src': ["'self'", 'https://github.com', 'https://raw.githubusercontent.com'],
+        'img-src': ["'self'", 'https://github.com', 'https://*.githubusercontent.com'],
         // allow connection from keycloak and opensrp server
         'connect-src': [
           "'self'",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -54,7 +54,17 @@ const sessionName = EXPRESS_SESSION_NAME;
 const app = express();
 
 app.use(compression()); // Compress all routes
-app.use(helmet()); // protect against well known vulnerabilities
+// helps mitigate cross-site scripting attacks and other known vulnerabilities
+app.use(
+  helmet.contentSecurityPolicy({
+    // override default script-src directive to include cloudflare cdn
+    // should consider overriding this to allow individual front-ends set Content-Security-Policy on meta tags themselves if list of exceptions grow
+    // like so: <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com;" >
+    directives: {
+      'script-src': ["'self'", 'https://cdnjs.cloudflare.com'],
+    },
+  }),
+);
 app.use(morgan('combined', { stream: winstonStream })); // send logs to winston
 
 const FileStore = sessionFileStore(session);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -57,11 +57,12 @@ app.use(compression()); // Compress all routes
 // helps mitigate cross-site scripting attacks and other known vulnerabilities
 app.use(
   helmet.contentSecurityPolicy({
-    // override default script-src directive to include cloudflare cdn
+    // override default script-src directive to include cloudflare cdn, and github static content
     // should consider overriding this to allow individual front-ends set Content-Security-Policy on meta tags themselves if list of exceptions grow
     // like so: <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com;" >
     directives: {
       'script-src': ["'self'", 'https://cdnjs.cloudflare.com', "'unsafe-inline'"],
+      'img-src': ["'self'", 'https://github.com', 'https://raw.githubusercontent.com'],
     },
   }),
 );

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -65,8 +65,12 @@ app.use(
       directives: {
         'script-src': ["'self'", 'https://cdnjs.cloudflare.com', "'unsafe-inline'"],
         'img-src': ["'self'", 'https://github.com', 'https://raw.githubusercontent.com'],
-        // allow connection from keycloak
-        'connect-src': ["'self'", ...getOriginFromUrl(EXPRESS_OPENSRP_AUTHORIZATION_URL)],
+        // allow connection from keycloak and opensrp server
+        'connect-src': [
+          "'self'",
+          ...getOriginFromUrl(EXPRESS_OPENSRP_AUTHORIZATION_URL),
+          ...getOriginFromUrl(EXPRESS_OPENSRP_USER_URL),
+        ],
       },
     },
   }),

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -56,14 +56,9 @@ const app = express();
 app.use(compression()); // Compress all routes
 // helps mitigate cross-site scripting attacks and other known vulnerabilities
 app.use(
-  helmet.contentSecurityPolicy({
-    // override default script-src directive to include cloudflare cdn, and github static content
-    // should consider overriding this to allow individual front-ends set Content-Security-Policy on meta tags themselves if list of exceptions grow
-    // like so: <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'  https://cdnjs.cloudflare.com; 'img-src' 'self' https://github.com https://raw.githubusercontent.com;" >
-    directives: {
-      'script-src': ["'self'", 'https://cdnjs.cloudflare.com', "'unsafe-inline'"],
-      'img-src': ["'self'", 'https://github.com', 'https://raw.githubusercontent.com'],
-    },
+  helmet({
+    // disable content security policy - it blocks cdn import of scripts and connection to other endpoints (e.g. keyckloak)
+    contentSecurityPolicy: false,
   }),
 );
 app.use(morgan('combined', { stream: winstonStream })); // send logs to winston

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -61,7 +61,7 @@ app.use(
     // should consider overriding this to allow individual front-ends set Content-Security-Policy on meta tags themselves if list of exceptions grow
     // like so: <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com;" >
     directives: {
-      'script-src': ["'self'", 'https://cdnjs.cloudflare.com'],
+      'script-src': ["'self'", 'https://cdnjs.cloudflare.com', "'unsafe-inline'"],
     },
   }),
 );

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -73,6 +73,7 @@ app.use(
         ],
       },
     },
+    crossOriginEmbedderPolicy: false,
   }),
 );
 app.use(morgan('combined', { stream: winstonStream })); // send logs to winston

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,15 @@
+/**
+ * get the url origin from full url
+ * e.g https://keycloak-example.domain.org from https://keycloak-example.domain.org/auth/realms/example-realm
+ * @param url
+ * @returns
+ */
+export const getOriginFromUrl = (url?: string) => {
+  if (!url) {
+    return [];
+  }
+  const urlObject = new URL(url);
+  return [urlObject.origin];
+};
+
+export default getOriginFromUrl;

--- a/src/utils/tests/index.test.ts
+++ b/src/utils/tests/index.test.ts
@@ -1,0 +1,9 @@
+import { getOriginFromUrl } from '../index';
+
+describe('test util functions', () => {
+  it('get origin from url', () => {
+    const url = 'https://keycloak-example.domain.org/auth/realms/example-realm';
+    const result = getOriginFromUrl(url);
+    expect(result).toEqual(['https://keycloak-example.domain.org']);
+  });
+});

--- a/src/utils/tests/index.test.ts
+++ b/src/utils/tests/index.test.ts
@@ -6,4 +6,11 @@ describe('test util functions', () => {
     const result = getOriginFromUrl(url);
     expect(result).toEqual(['https://keycloak-example.domain.org']);
   });
+  it('returns empty array if url is empty or undefined', () => {
+    const emptyUrl = '';
+    const emptyUrlResult = getOriginFromUrl(emptyUrl);
+    const undefinedUrlResult = getOriginFromUrl();
+    expect(emptyUrlResult).toEqual([]);
+    expect(undefinedUrlResult).toEqual([]);
+  });
 });


### PR DESCRIPTION
- add cross origin endpoints to whitelist to the Content Security Policy (CSP) header
	- static ones like cloudflare and github and dynamic from envs like keycloak and opensrp server
- ease Cross-Origin-Embedder-Policy to allow embedding images without explicit cors requests (provided they pass CSP) 